### PR TITLE
fix tracing breaks when render() is called too quickly (when onDidSav…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.0.6
+- fix: tracing does not work after changing graph and re-rendering it #3
+- fix: rendering for .dot files if graphviz language support is not installed. update graph for `languageId==DOT` or `filename.endsWith(DOT)`. might still not refresh for unsaved files. #4
+
 ## 0.0.5
 - Add support for VSCode on Windows
   - change toolbar style to orange (okay for dark/light themes)

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "graphviz-interactive-preview",
     "displayName": "Graphviz Interactive Preview",
     "description": "Graphviz (dot) Interactive Preview",
-    "version": "0.0.5",
+    "version": "0.0.6",
     "keywords": [
         "dot",
         "graphviz",

--- a/src/extension.js
+++ b/src/extension.js
@@ -24,7 +24,7 @@ function onActivate(context) {
     const graphvizView = new InteractiveWebviewGenerator(context, "content");
 
     vscode.workspace.onDidChangeTextDocument(event => {
-        if (event.document.languageId==DOT) {
+        if (event.document.languageId==DOT || event.document.fileName.trim().toLowerCase().endsWith(".dot")) {
             let panel = graphvizView.getPanel(event.document.uri);
             if(panel){
                 panel.renderDot(event.document.getText());
@@ -33,7 +33,7 @@ function onActivate(context) {
     }, null, context.subscriptions);
 
     context.subscriptions.push(vscode.workspace.onDidSaveTextDocument(doc => {
-        if (doc.languageId==DOT) {
+        if (doc.languageId==DOT || doc.fileName.trim().toLowerCase().endsWith(".dot")) {
             let panel = graphvizView.getPanel(doc.uri);
             if(panel){
                 panel.renderDot(doc.getText());

--- a/src/features/interactiveWebview.js
+++ b/src/features/interactiveWebview.js
@@ -186,7 +186,7 @@ class PreviewPanel {
         this.uri = uri;
         this.panel = panel;
 
-        this.lockRender = false;
+        this.lastRender = null;
     }
 
     reveal(displayColumn) {
@@ -206,8 +206,8 @@ class PreviewPanel {
     }
 
     renderDot(dotSrc) {
-        if(this.lockRender) return;  //naive approach: do not call render if it is already rendering (onDidSave fires a lot of events)
-        this.lockRender = true;
+        if(this.lastRender && Date.now() - this.lastRender <= 5000) return;  //naive approach: do not call render if it is already rendering (onDidSave fires a lot of events)
+        this.lastRender = Date.now();
         this.panel.webview.postMessage({ command: 'renderDot', value: dotSrc });
     }
 

--- a/src/features/interactiveWebview.js
+++ b/src/features/interactiveWebview.js
@@ -79,11 +79,14 @@ class InteractiveWebviewGenerator {
         console.log(`Message received from the webview: ${message.command}`);
 
         switch(message.command){
+            case 'onRenderFinished':
+                previewPanel.onRenderFinished(message);
+                break;
             case 'onPageLoaded':
-                previewPanel.onPageLoaded(message.value);
+                previewPanel.onPageLoaded(message);
                 break;
             case 'onClick':
-                previewPanel.onClick(message.value);
+                previewPanel.onClick(message);
                 break;
             case 'onDblClick':
                 console.log("dblclick --> navigate to code location");
@@ -182,6 +185,8 @@ class PreviewPanel {
         this.needsRebuild = false;
         this.uri = uri;
         this.panel = panel;
+
+        this.lockRender = false;
     }
 
     reveal(displayColumn) {
@@ -201,11 +206,17 @@ class PreviewPanel {
     }
 
     renderDot(dotSrc) {
+        if(this.lockRender) return;  //naive approach: do not call render if it is already rendering (onDidSave fires a lot of events)
+        this.lockRender = true;
         this.panel.webview.postMessage({ command: 'renderDot', value: dotSrc });
     }
 
     handleMessage(message){
         console.warn('Unexpected command: ' + message.command);
+    }
+
+    onRenderFinished(message){
+        this.lockRender = false;
     }
 
     onPageLoaded(message){


### PR DESCRIPTION
tracing might break when modifying and re-rendering a file if `render()` is called too often. 
this is a hack that makes sure that render is only called if the previous graph finished rendering. (might skip the latest change)