### PR TITLE
return JSONified graph domElem onClick onDblClick - refs #18

### DIFF
--- a/content/index.html
+++ b/content/index.html
@@ -128,6 +128,16 @@
     };
     </script>
     <script>
+        function DomToJsonAttribs(element) {
+            var result = {}
+            const attribs = element.attributes;
+            for(let i=0; i<attribs.length; i++) {
+                let a = attribs[i];
+                result[a.name] = a.value;
+            }
+            return result;
+        }
+
         $(document).ready(function(){
             // this inits the graphviz object from jquery.grapviz.svg.js
             $("#graph").graphviz({
@@ -150,7 +160,7 @@
                         vscode.postMessage({
                             command:'onClick', value:{
                                 // I guess: TODO: report which node was clicked
-                                node:"this",
+                                node:DomToJsonAttribs(this),
                             }
                         })
                     })
@@ -158,7 +168,7 @@
                         vscode.postMessage({
                             command:'onDblClick', value:{
                                 // I guess: TODO: report which node was clicked, to show the code?
-                                node:"this",
+                                node:DomToJsonAttribs(this),
                             }
                         })
                     })


### PR DESCRIPTION

```dot
digraph D {

  A [shape=diamond]
  B [shape=box]
  C [shape=circle]

  A -> B [style=dashed, color=grey]
  A -> C [color="black:invis:black"]
  A -> D [penwidth=5, arrowhead=none]

}
```

onclick events would return this to the graphviz callback:
```json
{"command":"onClick","value":{"node":{"id":"node3","class":"node","data-name":"C"}}}
{"command":"onDblClick","value":{"node":{"id":"node2","class":"node","data-name":"B"}}}
{"command":"onClick","value":{"node":{"id":"node2","class":"node","data-name":"B"}}}
```