### PR TITLE
Highlighting works with ports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,5 @@ typings/
 
 .vscode-test-web
 .vscode
+
+package-lock.json

--- a/.gitignore
+++ b/.gitignore
@@ -62,5 +62,3 @@ typings/
 
 .vscode-test-web
 .vscode
-
-package-lock.json

--- a/content/graphvizSvg/jquery.graphviz.svg.js
+++ b/content/graphvizSvg/jquery.graphviz.svg.js
@@ -415,10 +415,12 @@
       var $retval = $()
       this.findLinked(node, includeEdges, function (nodeName, edgeName) {
         var other = null;
-        var match = '->' + nodeName
-        if (edgeName.endsWith(match)) {
-          other = edgeName.substring(0, edgeName.length - match.length);
+
+        const connection = edgeName.split("->");
+        if(connection.length>1 && (connection[1] === nodeName || connection[1].startsWith(nodeName+":"))) {
+          return connection[0].split(":")[0];
         }
+
         return other;
       }, $retval)
       return $retval
@@ -428,9 +430,10 @@
       var $retval = $()
       this.findLinked(node, includeEdges, function (nodeName, edgeName) {
         var other = null;
-        var match = nodeName + '->'
-        if (edgeName.startsWith(match)) {
-          other = edgeName.substring(match.length);
+        
+        const connection = edgeName.split("->");
+        if(connection.length>1 && (connection[0] === nodeName || connection[0].startsWith(nodeName+":"))) {
+          return connection[1].split(":")[0];
         }
         return other;
       }, $retval)

--- a/content/index.html
+++ b/content/index.html
@@ -53,6 +53,11 @@
         <input type="submit" name="b1" value="Find" />
     </form>
 
+    <div id="faulttoolbar" class="toolbar-danger">
+        <span id="faultmessage" class="toolbar-item">
+        </span>
+    </div>
+
     <div id="toolbar-options" class="hidden">
             <a href="#" id="menu-save-dot" class="toolbar-item">DOT</a>
             <a href="#" id="menu-save-svg" class="toolbar-item">SVG</a>
@@ -72,8 +77,11 @@
     // object for saving configuration from the extension
     var viewConfig;
 
+    $("#faulttoolbar").hide();
+
     /** main render funcs **/
     function render(dotSrc) {
+        $("#faulttoolbar").hide();
         transition = d3.transition("startTransition")
             .ease(d3.easeLinear)
             .delay(viewConfig.transitionDelay)
@@ -87,6 +95,8 @@
             .zoomScaleExtent([0,Infinity])
             .zoom(true)
             .onerror(function (err) {
+                $('#faultmessage').html(err);
+                $("#faulttoolbar").show();
                 vscode.postMessage({
                     command:'onRenderFinished',
                     value:{ err }


### PR DESCRIPTION
At the moment the highlight function does not support ports. So if an edge is created which targets a specific port of a node, then the same port is needed for further highlighting. In most projects this is not wanted. The proposed fix takes care of ports and highlights the edges/nodes downstream or upstream of the selected node.

Sample DOT:
`digraph {
node [shape=box style=filled]
graph [rankdir="LR"]
n2 [
label="<f0> + | <f1> +"
shape="record"
]
n1 -> n2:f0
n2:f1 -> n3
}`