### PR TITLE
Highlighting works with ports

### DIFF
--- a/content/graphvizSvg/jquery.graphviz.svg.js
+++ b/content/graphvizSvg/jquery.graphviz.svg.js
@@ -415,10 +415,12 @@
       var $retval = $()
       this.findLinked(node, includeEdges, function (nodeName, edgeName) {
         var other = null;
-        var match = '->' + nodeName
-        if (edgeName.endsWith(match)) {
-          other = edgeName.substring(0, edgeName.length - match.length);
+
+        const connection = edgeName.split("->");
+        if(connection.length>1 && (connection[1] === nodeName || connection[1].startsWith(nodeName+":"))) {
+          return connection[0].split(":")[0];
         }
+
         return other;
       }, $retval)
       return $retval
@@ -428,9 +430,10 @@
       var $retval = $()
       this.findLinked(node, includeEdges, function (nodeName, edgeName) {
         var other = null;
-        var match = nodeName + '->'
-        if (edgeName.startsWith(match)) {
-          other = edgeName.substring(match.length);
+        
+        const connection = edgeName.split("->");
+        if(connection.length>1 && (connection[0] === nodeName || connection[0].startsWith(nodeName+":"))) {
+          return connection[1].split(":")[0];
         }
         return other;
       }, $retval)


### PR DESCRIPTION
At the moment the highlight function does not support ports. So if an edge is created which targets a specific port of a node, then the same port is needed for further highlighting. In most projects this is not wanted. The proposed fix takes care of ports and highlights the edges/nodes downstream or upstream of the selected node.

Sample DOT:
`digraph {
node [shape=box style=filled]
graph [rankdir="LR"]
n2 [
label="<f0> + | <f1> +"
shape="record"
]
n1 -> n2:f0
n2:f1 -> n3
}`