### PR TITLE
Error Messages in Webview

### DIFF
--- a/content/index.html
+++ b/content/index.html
@@ -53,6 +53,11 @@
         <input type="submit" name="b1" value="Find" />
     </form>
 
+    <div id="faulttoolbar" class="toolbar-danger">
+        <span id="faultmessage" class="toolbar-item">
+        </span>
+    </div>
+
     <div id="toolbar-options" class="hidden">
             <a href="#" id="menu-save-dot" class="toolbar-item">DOT</a>
             <a href="#" id="menu-save-svg" class="toolbar-item">SVG</a>
@@ -73,8 +78,11 @@
     // object for saving configuration from the extension
     var viewConfig;
 
+    $("#faulttoolbar").hide();
+
     /** main render funcs **/
     function render(dotSrc) {
+        $("#faulttoolbar").hide();
         transition = d3.transition("startTransition")
             .ease(d3.easeLinear)
             .delay(viewConfig.transitionDelay)
@@ -88,6 +96,8 @@
             .zoomScaleExtent([0,Infinity])
             .zoom(true)
             .onerror(function (err) {
+                $('#faultmessage').html(err);
+                $("#faulttoolbar").show();
                 vscode.postMessage({
                     command:'onRenderFinished',
                     value:{ err }


### PR DESCRIPTION
Current situation:
At the moment render errors (e.g. due to malformatted DOT strings/files) are not shown in the render view.
Instead the view stays on the last successfully rendered DOT source. There is no visual indication, that the current input fails to render.

Implementation:
The proposed fix is to show a red error toolbar once a fault occurs. It is hidden on a rerender.

Screenshot:
<img width="719" alt="Screenshot 2022-01-11 at 17 57 56" src="https://user-images.githubusercontent.com/27259/148987169-ebebd6e2-3266-4840-9e2a-805c2a845cc6.png">
 