### PR TITLE
Select Node Highlight mode for Upstream/Downstream/Bidirectional

### DIFF
--- a/content/index.html
+++ b/content/index.html
@@ -51,6 +51,11 @@
         <span id="toolbar">&nbsp;&#x2699;&#xFE0F;&nbsp;</span>
         <input type="text" class="t1" name="t1" value="" placeholder="search..."/>
         <input type="submit" name="b1" value="Find" />
+        <select id="streamdirection">
+            <option value="bidirectional">Bidirectional</option>
+            <option value="downstream">Downstream</option>
+            <option value="upstream">Upstream</option>
+        </select>
     </form>
 
     <div id="toolbar-options" class="hidden">
@@ -153,8 +158,13 @@
                     gv.nodes().click(function () {
                         var $set = $()
                         $set.push(this)
-                        $set = $set.add(gv.linkedFrom(this, true))
-                        $set = $set.add(gv.linkedTo(this, true))
+                        var $direction = $('#streamdirection').val();
+                        if ($direction==="bidirectional" || $direction==="downstream") {
+                            $set = $set.add(gv.linkedFrom(this, true))
+                        }
+                        if ($direction==="bidirectional" || $direction==="upstream") {
+                            $set = $set.add(gv.linkedTo(this, true))
+                        }
                         gv.highlight($set, true)
                         gv.bringToFront($set)
 


### PR DESCRIPTION
This PR implements the feature request by @justinchuby in #27

In the GraphViz Preview Window there is now a dropdown in which the selection mode can be chosen.

<img width="503" alt="Screenshot 2022-01-13 at 00 00 29" src="https://user-images.githubusercontent.com/27259/149236593-beb4a3e9-3900-4566-a285-eaadc7c01c38.png">


<img width="503" alt="Screenshot 2022-01-13 at 00 01 16" src="https://user-images.githubusercontent.com/27259/149236702-0efad712-3dd7-4db2-a3c4-0a4311c1387f.png">
