### PR TITLE
create content/dist if it does not exist

### DIFF
--- a/updateDependencies.js
+++ b/updateDependencies.js
@@ -1,5 +1,9 @@
 const fs = require('fs');
 
+if (!fs.existsSync('content/dist/')){
+  fs.mkdirSync('content/dist/');
+}
+
 fs.copyFile('node_modules/@hpcc-js/wasm/dist/graphvizlib.wasm', 'content/dist/graphvizlib.wasm', (err) => {
   if (err) throw err;
   console.log('graphvizlib.wasm was copied to content/dist');


### PR DESCRIPTION
`content/dist` does not exist on first checkout which leads to an error when running `updateDeps` as part of `npm install` as the target dir does not exist.