### PR TITLE
Symbols, Rename and References (fixes #79)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -17,4 +17,8 @@
         "javascript",
         "typescript"
     ],
+    "cSpell.words": [
+        "graphviz",
+        "tintinweb"
+    ],
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,15 +11,9 @@ import PreviewPanel from "./features/previewPanel";
 import ColorProvider from "./language/ColorProvider";
 import DotCompletionItemProvider from "./language/CompletionItemProvider";
 import DotHoverProvider from "./language/HoverProvider";
+import SymbolProvider from "./language/SymbolProvider";
 import * as settings from "./settings";
 
-/** global vars */
-
-/** classdecs */
-
-/** funcdecs */
-
-/** event funcs */
 function onActivate(context: vscode.ExtensionContext) {
   const graphvizView = new InteractiveWebviewGenerator(context);
 
@@ -108,6 +102,20 @@ function onActivate(context: vscode.ExtensionContext) {
   context.subscriptions.push(vscode.languages.registerHoverProvider(
     [settings.languageId],
     new DotHoverProvider(),
+  ));
+
+  const symProvider = new SymbolProvider();
+  context.subscriptions.push(vscode.languages.registerDocumentSymbolProvider(
+    [settings.languageId],
+    symProvider,
+  ));
+  context.subscriptions.push(vscode.languages.registerRenameProvider(
+    [settings.languageId],
+    symProvider,
+  ));
+  context.subscriptions.push(vscode.languages.registerReferenceProvider(
+    [settings.languageId],
+    symProvider,
   ));
 }
 

--- a/src/language/SymbolProvider.ts
+++ b/src/language/SymbolProvider.ts
@@ -1,0 +1,262 @@
+import {
+  DocumentSymbolProvider,
+  Location,
+  Position,
+  Range,
+  ReferenceProvider,
+  RenameProvider,
+  SymbolInformation,
+  SymbolKind,
+  TextDocument,
+  WorkspaceEdit,
+} from "vscode";
+
+export default class SymbolProvider
+implements
+    DocumentSymbolProvider,
+    RenameProvider,
+    ReferenceProvider {
+  // eslint-disable-next-line class-methods-use-this
+  private lineIterator(
+    document: TextDocument,
+    regex: RegExp,
+    // eslint-disable-next-line no-unused-vars
+    func: (lineNumber: number, captures: RegExpExecArray, offset: number) => SymbolInformation[],
+  ) {
+    let symbols: SymbolInformation[] = [];
+    for (let line = 0; line < document.lineCount; line += 1) {
+      const t = document.lineAt(line).text;
+      let match;
+      // eslint-disable-next-line no-cond-assign
+      while ((match = regex.exec(t)) != null) {
+        const offset = match.index + 1;
+        const res = func(line, match, offset);
+        symbols = symbols.concat(res);
+      }
+    }
+    return symbols;
+  }
+
+  // find node definitions
+  // /node\s*\[.*\]\s([\w\d]+|"(?:[^"\\]|\\.)*")/g
+  private findExplicitNodeDefinition(document: TextDocument): SymbolInformation[] {
+    const regex = /node\s*\[.*\]\s([\w\d]+|"(?:[^"\\]|\\.)*")/g;
+
+    return this.lineIterator(
+      document,
+      regex,
+      (
+        lineNumber: number,
+        capture: RegExpExecArray,
+        offset: number,
+      ): SymbolInformation[] => [new SymbolInformation(
+        capture[1],
+        SymbolKind.Variable,
+        "",
+        new Location(
+          document.uri,
+          new Range(
+            new Position(
+              lineNumber,
+              offset + capture[0].length - capture[1].length,
+            ),
+            new Position(
+              lineNumber,
+              offset + capture[0].length,
+            ),
+          ),
+        ),
+      )],
+    );
+  }
+
+  // find inline nodes
+  // /^\s*((([\w\d]+)\s*)+)(?!.*(=|->|{|\[))/g
+  private findNodeDefinition(document: TextDocument): SymbolInformation[] {
+    const regex = /^\s*((([\w\d]+|"(?:[^"\\]|\\.)*")\s*)+)(?!.*(=|->|{|\[))/g;
+    const regexSymbol = /([\w\d]+|"(?:[^"\\]|\\.)*")/g;
+
+    return this.lineIterator(
+      document,
+      regex,
+      (
+        lineNumber: number,
+        captures: RegExpExecArray,
+        offset: number,
+      ): SymbolInformation[] => {
+        const symbols: SymbolInformation[] = [];
+        let symbol;
+        // eslint-disable-next-line no-cond-assign
+        while ((symbol = regexSymbol.exec(captures[0])) != null) {
+          symbols.push(
+            new SymbolInformation(
+              symbol[0],
+              SymbolKind.Variable,
+              "",
+              new Location(
+                document.uri,
+                new Range(
+                  new Position(lineNumber, offset + symbol.index - 1),
+                  new Position(lineNumber, offset + symbol.index - 1 + symbol[0].length),
+                ),
+              ),
+            ),
+          );
+        }
+        return symbols;
+      },
+    );
+  }
+
+  // find Nodes with config
+  private findNodeDefinitionWithConfig(document: TextDocument) : SymbolInformation[] {
+    const regex = /(?!\s*node)^\s*(([\w\d]+|"(?:[^"\\]|\\.)*"))\s*\[/g;
+
+    return this.lineIterator(
+      document,
+      regex,
+      (
+        lineNumber: number,
+        capture: RegExpExecArray,
+        offset: number,
+      ): SymbolInformation[] => [new SymbolInformation(
+        capture[1],
+        SymbolKind.Variable,
+        "",
+        new Location(
+          document.uri,
+          new Range(
+            new Position(
+              lineNumber,
+              offset + capture.index + (capture[0].length - capture[0].trim().length) - 1,
+            ),
+            new Position(
+              lineNumber,
+              offset + capture.index
+              + (capture[0].length - capture[0].trim().length)
+              + capture[1].length - 1,
+            ),
+          ),
+        ),
+      )],
+    );
+  }
+
+  private findRegularSymbols(document: TextDocument) : SymbolInformation[] {
+    const regex = /([\w\d]+|"(?:[^"\\]|\\.)*")(\s*(->|<-|--)\s*([\w\d]+|"(?:[^"\\]|\\.)*"))+/g;
+    const regexSymbol = /[\w\d]+|"(?:[^"\\]|\\.)*"/g;
+
+    return this.lineIterator(
+      document,
+      regex,
+      (
+        lineNumber: number,
+        captures: RegExpExecArray,
+        offset: number,
+      ) : SymbolInformation[] => {
+        const symbols: SymbolInformation[] = [];
+        let symbol;
+        // eslint-disable-next-line no-cond-assign
+        while ((symbol = regexSymbol.exec(captures[0])) != null) {
+          symbols.push(
+            new SymbolInformation(
+              symbol[0],
+              SymbolKind.Variable,
+              "",
+              new Location(
+                document.uri,
+                new Range(
+                  new Position(lineNumber, offset + symbol.index - 1),
+                  new Position(lineNumber, offset + symbol.index - 1 + symbol[0].length),
+                ),
+              ),
+            ),
+          );
+        }
+        return symbols;
+      },
+    );
+  }
+
+  public provideSymbols(document: TextDocument) : SymbolInformation[] {
+    let symbols : SymbolInformation[] = [];
+
+    symbols = symbols.concat(this.findExplicitNodeDefinition(document));
+    symbols = symbols.concat(this.findNodeDefinition(document));
+    symbols = symbols.concat(this.findRegularSymbols(document));
+    symbols = symbols.concat(this.findNodeDefinitionWithConfig(document));
+
+    return symbols;
+  }
+
+  public provideDocumentSymbols(
+    document: TextDocument,
+    // token: CancellationToken,
+  ): Promise<SymbolInformation[]> {
+    return Promise.resolve(this.provideSymbols(document));
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  private containingSymbol(symbols: SymbolInformation[], position: Position) {
+    let renameSymbol: SymbolInformation|undefined;
+    symbols.forEach((symbol) => {
+      if (symbol.location.range.contains(position)) {
+        renameSymbol = symbol;
+      }
+    });
+    return renameSymbol;
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  public provideRenameEdits(
+    document: TextDocument,
+    position: Position,
+    newName: string,
+  // token: CancellationToken,
+  ):
+    Promise<WorkspaceEdit> {
+    return this.provideDocumentSymbols(document).then((symbols) => {
+      const edit:WorkspaceEdit = new WorkspaceEdit();
+
+      const renameSymbol = this.containingSymbol(symbols, position);
+      if (!renameSymbol) {
+        return Promise.reject();
+      }
+
+      symbols.forEach((symbol) => {
+        if (renameSymbol?.name === symbol.name) {
+          edit.replace(
+            document.uri,
+            symbol.location.range,
+            newName,
+          );
+        }
+      });
+
+      return Promise.resolve(edit);
+    });
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  public provideReferences(
+    document: TextDocument,
+    position: Position,
+    // options: { includeDeclaration: boolean },
+    // token: CancellationToken,
+  ):
+    Promise<Location[]> {
+    return this.provideDocumentSymbols(document).then((symbols) => {
+      const findSymbol = this.containingSymbol(symbols, position);
+      if (!findSymbol) {
+        return Promise.reject();
+      }
+      const locations : Location[] = [];
+      symbols.forEach((symbol) => {
+        if (findSymbol?.name === symbol.name) {
+          locations.push(symbol.location);
+        }
+      });
+      return Promise.resolve(locations);
+    });
+  }
+}

--- a/src/language/SymbolProvider.ts
+++ b/src/language/SymbolProvider.ts
@@ -219,7 +219,10 @@ implements
       return Promise.reject(new Error("This can not be renamed."));
     }
 
-    return renameSymbol.location.range;
+    return {
+      range: renameSymbol.location.range,
+      placeholder: renameSymbol.name[0] === "\"" && renameSymbol.name[renameSymbol.name.length - 1] === "\"" ? renameSymbol.name.substring(1, renameSymbol.name.length - 1) : renameSymbol.name,
+    };
   }
 
   public provideRenameEdits(
@@ -237,12 +240,17 @@ implements
         return Promise.reject();
       }
 
+      let newSymbolName = newName;
+      if (!newName.match(/^[\w\d]+$/) && !(newName[0] === "\"" && newName[newName.length - 1] === "\"")) {
+        newSymbolName = `"${newName.replace(/\\{0,1}"/g, "\\\"")}"`;
+      }
+
       symbols.forEach((symbol) => {
         if (renameSymbol?.name === symbol.name) {
           edit.replace(
             document.uri,
             symbol.location.range,
-            newName,
+            newSymbolName,
           );
         }
       });

--- a/src/language/SymbolProvider.ts
+++ b/src/language/SymbolProvider.ts
@@ -2,6 +2,7 @@ import {
   DocumentSymbolProvider,
   Location,
   Position,
+  ProviderResult,
   Range,
   ReferenceProvider,
   RenameProvider,
@@ -207,7 +208,20 @@ implements
     return renameSymbol;
   }
 
-  // eslint-disable-next-line class-methods-use-this
+  public prepareRename(
+    document: TextDocument,
+    position: Position,
+    // token: CancellationToken
+  ): ProviderResult<Range | { range: Range; placeholder: string }> {
+    const symbols = this.provideSymbols(document);
+    const renameSymbol = this.containingSymbol(symbols, position);
+    if (!renameSymbol) {
+      return Promise.reject(new Error("This can not be renamed."));
+    }
+
+    return renameSymbol.location.range;
+  }
+
   public provideRenameEdits(
     document: TextDocument,
     position: Position,

--- a/test/corpi/differentNodeTypes.dot
+++ b/test/corpi/differentNodeTypes.dot
@@ -13,4 +13,5 @@ digraph {
     t[label="t"]
     "u" [label="u"]
     v [label="v"] "w"[label="w"]
+    "x x x"
 }

--- a/test/corpi/differentNodeTypes.dot
+++ b/test/corpi/differentNodeTypes.dot
@@ -1,0 +1,16 @@
+digraph {
+    a;
+    node [color=black] b;
+    c d e
+    e f;
+    "g";
+    h -> i
+    j -> k -> l
+    m -> "n"
+    "o" -> "p"
+    "q" -> r
+    "s \""
+    t[label="t"]
+    "u" [label="u"]
+    v [label="v"] "w"[label="w"]
+}


### PR DESCRIPTION
This commit introduces more symbol recognitions.
A new test file (differentNodeTypes.dot) has been introduced. Currently only `w` is not recognised.

The update offers proper symbols (Press `Ctrl+P` and afterwards enter `@`)
<img width="756" alt="Screenshot 2022-04-13 at 23 36 20" src="https://user-images.githubusercontent.com/27259/163274489-6bc4627e-f545-47f1-a674-a7b551583d34.png">

Renaming is now offered:
<img width="390" alt="Screenshot 2022-04-13 at 23 38 42" src="https://user-images.githubusercontent.com/27259/163274816-7a49ff59-c4a5-4d35-92b6-7958b32cad7b.png">

References can be found:
<img width="666" alt="Screenshot 2022-04-13 at 23 40 07" src="https://user-images.githubusercontent.com/27259/163274997-6e696418-c9de-4fa8-800d-fbf0bee2e7de.png">

