### PR TITLE
API - Allow caller to define view options (preserveFocus, vieColumn) and fix panel matching when "openAutomatically"

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -96,6 +96,10 @@ function onActivate(context: vscode.ExtensionContext) {
         options.uri = options.document.uri;
       }
 
+      if (typeof options.displayColumn === "object" && options.displayColumn.preserveFocus === undefined) {
+        options.displayColumn.preserveFocus = settings.extensionConfig().get("preserveFocus"); // default to user settings
+      }
+
       const execute = (o:any) => {
         graphvizView.revealOrCreatePreview(
           o.displayColumn,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -67,6 +67,10 @@ function onActivate(context: vscode.ExtensionContext) {
         allowMultiplePanels?: boolean,
         title?: string,
         search?: any,
+        displayColumn?: vscode.ViewColumn | {
+          viewColumn: vscode.ViewColumn;
+          preserveFocus?: boolean | undefined;
+        }
       } = {
         document: args.document,
         uri: args.uri,
@@ -75,6 +79,10 @@ function onActivate(context: vscode.ExtensionContext) {
         allowMultiplePanels: args.allowMultiplePanels,
         title: args.title,
         search: args.search,
+        displayColumn: args.displayColumn || {
+          viewColumn: vscode.ViewColumn.Beside,
+          preserveFocus: settings.extensionConfig().get("preserveFocus"),
+        },
       };
 
       if (!options.content
@@ -90,10 +98,7 @@ function onActivate(context: vscode.ExtensionContext) {
 
       const execute = (o:any) => {
         graphvizView.revealOrCreatePreview(
-          {
-            viewColumn: vscode.ViewColumn.Beside,
-            preserveFocus: settings.extensionConfig().get("preserveFocus"),
-          },
+          o.displayColumn,
           o.uri,
           o,
         )

--- a/src/features/interactiveWebview.ts
+++ b/src/features/interactiveWebview.ts
@@ -21,7 +21,7 @@ const webviewPanelContent = require("../../content/index.html").default;
 export default class InteractiveWebviewGenerator {
   private context: vscode.ExtensionContext;
 
-  private webviewPanels: Map<vscode.Uri, PreviewPanel>;
+  private webviewPanels: Map<String, PreviewPanel>;
 
   constructor(context: vscode.ExtensionContext) {
     this.context = context;
@@ -29,7 +29,7 @@ export default class InteractiveWebviewGenerator {
   }
 
   setNeedsRebuild(uri: vscode.Uri, needsRebuild: boolean) {
-    const panel = this.webviewPanels.get(uri);
+    const panel = this.webviewPanels.get(uri.toString());
 
     if (panel) {
       panel.setNeedsRebuild(needsRebuild);
@@ -38,7 +38,7 @@ export default class InteractiveWebviewGenerator {
   }
 
   getPanel(uri: vscode.Uri) {
-    return this.webviewPanels.get(uri);
+    return this.webviewPanels.get(uri.toString());
   }
 
   // eslint-disable-next-line class-methods-use-this
@@ -68,10 +68,14 @@ export default class InteractiveWebviewGenerator {
     const that = this;
 
     return new Promise((resolve, reject) => {
-      let previewPanel = (uri) ? that.webviewPanels.get(uri) : undefined;
+      let previewPanel = (uri) ? that.webviewPanels.get(uri.toString()) : undefined;
 
       if (previewPanel && !options.allowMultiplePanels) {
-        previewPanel.reveal(isObject(displayColumn) ? displayColumn.viewColumn : displayColumn);
+        if (!isObject(displayColumn)) {
+          previewPanel.reveal(displayColumn);
+        } else {
+          previewPanel.reveal(displayColumn.viewColumn, displayColumn.preserveFocus);
+        }
       } else {
         previewPanel = that.createPreviewPanel(uri, displayColumn, options.title);
 
@@ -80,13 +84,13 @@ export default class InteractiveWebviewGenerator {
           return;
         }
         if (uri) {
-          that.webviewPanels.set(uri, previewPanel);
+          that.webviewPanels.set(uri.toString(), previewPanel);
         }
         // when the user closes the tab, remove the panel
         previewPanel.getPanel().onDidDispose(() => {
           previewPanel?.dispose();
           // eslint-disable-next-line no-sequences
-          if (uri) return that.webviewPanels.delete(uri), undefined, that.context.subscriptions;
+          if (uri) return that.webviewPanels.delete(uri.toString()), undefined, that.context.subscriptions;
           return that.context.subscriptions;
         });
         // when the pane becomes visible again, refresh it

--- a/src/features/interactiveWebview.ts
+++ b/src/features/interactiveWebview.ts
@@ -89,8 +89,10 @@ export default class InteractiveWebviewGenerator {
         // when the user closes the tab, remove the panel
         previewPanel.getPanel().onDidDispose(() => {
           previewPanel?.dispose();
-          // eslint-disable-next-line no-sequences
-          if (uri) return that.webviewPanels.delete(uri.toString()), undefined, that.context.subscriptions;
+          if (uri) {
+            // eslint-disable-next-line no-sequences
+            return that.webviewPanels.delete(uri.toString()), undefined, that.context.subscriptions;
+          }
           return that.context.subscriptions;
         });
         // when the pane becomes visible again, refresh it

--- a/src/features/previewPanel.ts
+++ b/src/features/previewPanel.ts
@@ -83,8 +83,8 @@ export default class PreviewPanel {
       : 0;
   }
 
-  reveal(displayColumn: vscode.ViewColumn) {
-    this.panel.reveal(displayColumn);
+  reveal(displayColumn: vscode.ViewColumn, preserveFocus?: boolean) {
+    this.panel.reveal(displayColumn, preserveFocus);
   }
 
   setNeedsRebuild(needsRebuild : boolean) {


### PR DESCRIPTION
fixes #131 

- allow caller to optionally provide a `vscode.ViewColumn` or `{vscode.ViewColumn, vscode.preserveFocus}` with command `graphviz-interactive-preview.preview.beside`. `vscode.preserveFocus` falls back to user settings unless overridden by the caller.

```typescript
graphviz-interactive-preview.preview.beside({..., displayColumn:{vscode.ViewColumn, vscode.preserveFocus})
``` 

- "openAutomatically" creates a new URI object. When revealing the graph for an already rendered `.dot` file the extension would open another render view because the lookup if the panel already exists fails as `vscode.URI` objects are not singletons (`new vscode.Uri("hi") != new vscode.Uri("hi")`. in order to fix this we now index `vscode.Uri.toString()` in the `URI -> panelObject` mapping. fixes https://github.com/tintinweb/vscode-interactive-graphviz/issues/131#issuecomment-1228644039