### PR TITLE
Only render if the panel is visible

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -25,7 +25,7 @@ function onActivate(context: vscode.ExtensionContext) {
     if (event.document.languageId === settings.languageId
         || event.document.fileName.trim().toLowerCase().endsWith(settings.fileExtension)) {
       const panel = graphvizView.getPanel(event.document.uri);
-      if (panel) {
+      if (panel && panel.isVisible()) {
         panel.requestRender(event.document.getText());
       }
     }
@@ -35,7 +35,7 @@ function onActivate(context: vscode.ExtensionContext) {
     if (doc.languageId === settings.languageId
         || doc.fileName.trim().toLowerCase().endsWith(settings.fileExtension)) {
       const panel = graphvizView.getPanel(doc.uri);
-      if (panel) {
+      if (panel && panel.isVisible()) {
         panel.requestRender(doc.getText());
       }
     }

--- a/src/features/previewPanel.ts
+++ b/src/features/previewPanel.ts
@@ -103,6 +103,10 @@ export default class PreviewPanel {
     return this.panel;
   }
 
+  public isVisible() {
+    return this.panel.visible;
+  }
+
   // the following functions do not use any locking/synchronization mechanisms,
   // so it may behave weirdly in edge cases
 


### PR DESCRIPTION
As I was editing my dot files with the preview panel closed, I noticed the `Rendering Graphviz View` notification popping up regularly. This change only performs rendering when the panel is visible.