### PR TITLE
Enable command URI in Webview

### DIFF
--- a/src/features/interactiveWebview.ts
+++ b/src/features/interactiveWebview.ts
@@ -197,6 +197,7 @@ export default class InteractiveWebviewGenerator {
     const webViewPanel = vscode.window.createWebviewPanel("graphvizPreview", previewTitle, displayColumn, {
       enableFindWidget: false,
       enableScripts: true,
+      enableCommandUris: true,
       retainContextWhenHidden: true,
       localResourceRoots: [
         Utils.joinPath(this.context.extensionUri, "content"),


### PR DESCRIPTION
Enabler for navigation to specific files in editor, directly from graph.
File URI is specified within `href` attribute of the `.dot` file, which extension gets as a content argument of `graphviz-interactive-preview.preview.beside` command.

_*Please check [this](https://www.eliostruyf.com/command-uri-vscode-webview-open-files-links/) article for additional details._