### PR TITLE
Fix bidirectional highlight when node identifier contains ":" symbol

### DIFF
--- a/content/graphvizSvg/jquery.graphviz.svg.js
+++ b/content/graphvizSvg/jquery.graphviz.svg.js
@@ -433,36 +433,33 @@
     GraphvizSvg.prototype.clustersByName = function () {
       return this._clustersByName
     }
-  
+
     GraphvizSvg.prototype.linkedTo = function (node, includeEdges) {
       var $retval = $()
       this.findLinked(node, includeEdges, function (nodeName, edgeName) {
         var other = null;
-
-        const connection = edgeName.split("->");
-        if(connection.length>1 && (connection[1] === nodeName || connection[1].startsWith(nodeName+":"))) {
-          return connection[0].split(":")[0];
+        var match = '->' + nodeName
+        if (edgeName.endsWith(match)) {
+          other = edgeName.substring(0, edgeName.length - match.length);
         }
-
         return other;
       }, $retval)
       return $retval
     }
-  
+
     GraphvizSvg.prototype.linkedFrom = function (node, includeEdges) {
       var $retval = $()
       this.findLinked(node, includeEdges, function (nodeName, edgeName) {
         var other = null;
-        
-        const connection = edgeName.split("->");
-        if(connection.length>1 && (connection[0] === nodeName || connection[0].startsWith(nodeName+":"))) {
-          return connection[1].split(":")[0];
+        var match = nodeName + '->'
+        if (edgeName.startsWith(match)) {
+          other = edgeName.substring(match.length);
         }
         return other;
       }, $retval)
       return $retval
     }
-  
+
     GraphvizSvg.prototype.linked = function (node, includeEdges) {
       var $retval = $()
       this.findLinked(node, includeEdges, function (nodeName, edgeName) {
@@ -560,5 +557,4 @@
       $.fn.graphviz = old
       return this
     }
-  
   }(jQuery)


### PR DESCRIPTION
fix: https://github.com/tintinweb/vscode-interactive-graphviz/issues/172

I have limited javascript experience and I'd like to keep the change minimum
so I just copied latest `GraphvizSvg.prototype.linkedTo` and `GraphvizSvg.prototype.linkedFrom` implementation from https://github.com/mountainstorm/jquery.graphviz.svg
I expect there is no much behavior change

after the fix:
![image](https://github.com/tintinweb/vscode-interactive-graphviz/assets/48843657/a917c0ad-a3cc-4ef9-b11d-e0aee5ab2275)
